### PR TITLE
Sailjail and opened auth page from Qt

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -17,6 +17,7 @@ if ("${SAILFISH_FOUND}")
     message("Building for Sailfish OS")
     add_compile_definitions(${PROJECT_NAME} WITH_SAILFISH)
     target_link_libraries(${PROJECT_NAME} ${SAILFISH_LDFLAGS})
+    target_include_directories(${PROJECT_NAME} PRIVATE ${SAILFISH_INCLUDE_DIRS})
 else()
     message("Building without Sailfish OS, for fast prototyping on desktop")
 endif()
@@ -26,9 +27,6 @@ if (${USE_SHIM})
 else()
     target_link_libraries(${PROJECT_NAME} elephant-seal-rs-cxx)
 endif()
-
-
-target_include_directories(${PROJECT_NAME} PRIVATE ${SAILFISH_INCLUDE_DIRS})
 
 install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION bin

--- a/bin/harbour-elephant-seal.desktop
+++ b/bin/harbour-elephant-seal.desktop
@@ -4,3 +4,8 @@ X-Nemo-Application-Type=silica-qt5
 Icon=harbour-elephant-seal
 Exec=harbour-elephant-seal
 Name=Elephant seal
+
+[X-Sailjail]
+Permissions=Internet;Camera;Pictures
+OrganizationName=com.github.SfietKonstantin
+ApplicationName=harbour-elephant-seal

--- a/bin/qml/pages/LoginPage.qml
+++ b/bin/qml/pages/LoginPage.qml
@@ -6,7 +6,10 @@ Page {
     MastodonLogin {
         id: login
         mastodon: mastodonInstance
-        onDisplayCodeInput: pageStack.push(codePage)
+        onOpenCodeUrl: {
+            Qt.openUrlExternally(url)
+            pageStack.push(codePage)
+        }
     }
 
     SilicaFlickable {

--- a/lib/lib/lib/eventbus.cpp
+++ b/lib/lib/lib/eventbus.cpp
@@ -5,6 +5,6 @@ EventBus::EventBus(QObject *parent)
 {
 }
 
-void EventBus::sendDisplayCodeInput(EventBus &bus) {
-    emit bus.displayCodeInput();
+void EventBus::sendOpenCodeUrl(EventBus &bus, const QString &url) {
+    emit bus.openCodeUrl(url);
 }

--- a/lib/lib/lib/eventbus.h
+++ b/lib/lib/lib/eventbus.h
@@ -6,7 +6,7 @@ class EventBus : public QObject {
     Q_OBJECT
 public:
     explicit EventBus(QObject *parent = nullptr);
-    static void sendDisplayCodeInput(EventBus &bus);
+    static void sendOpenCodeUrl(EventBus &bus, const QString &url);
 signals:
-    void displayCodeInput();
+    void openCodeUrl(const QString &url);
 };

--- a/lib/lib/lib/mastodonlogin.cpp
+++ b/lib/lib/lib/mastodonlogin.cpp
@@ -23,7 +23,7 @@ void MastodonLogin::setMastodon(Mastodon *mastodon) {
 
         if (mastodon != nullptr) {
             auto &bus = mastodon->eventBus();
-            connect(&bus, &EventBus::displayCodeInput, this, &MastodonLogin::displayCodeInput);
+            connect(&bus, &EventBus::openCodeUrl, this, &MastodonLogin::openCodeUrl);
         }
         emit mastodonChanged();
     }

--- a/lib/lib/lib/mastodonlogin.h
+++ b/lib/lib/lib/mastodonlogin.h
@@ -22,7 +22,7 @@ signals:
     void mastodonChanged();
     void serverChanged();
 
-    void displayCodeInput();
+    void openCodeUrl(const QString &url);
 
 private:
     Mastodon *m_mastodon{nullptr};

--- a/lib/rust/CMakeLists.txt
+++ b/lib/rust/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 
 include(FindPkgConfig)
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui REQUIRED)
 find_package(OpenSSL REQUIRED)
 pkg_search_module(SAILFISH sailfishapp)
 
@@ -43,4 +43,4 @@ add_library(${PROJECT_NAME} STATIC
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC .)
-target_link_libraries(${PROJECT_NAME} elephant-seal-lib elephant-seal-rs ${OPENSSL_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} elephant-seal-lib elephant-seal-rs Qt5::Gui ${OPENSSL_LIBRARIES})

--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -308,7 +308,6 @@ dependencies = [
  "indexmap",
  "log",
  "once_cell",
- "open",
  "pretend",
  "pretend-reqwest",
  "proc-macro2",
@@ -903,16 +902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
-name = "open"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
-dependencies = [
- "pathdiff",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,12 +968,6 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "cxx-qt-lib"
 version = "0.4.1"
-source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#455862f6a2c43d1ce98f699cbfd2af370aa70d10"
+source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#37b4148c77029622478ca84e00e93e00e4944095"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "cxx-qt-lib-headers"
 version = "0.4.1"
-source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#455862f6a2c43d1ce98f699cbfd2af370aa70d10"
+source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#37b4148c77029622478ca84e00e93e00e4944095"
 
 [[package]]
 name = "cxxbridge-flags"
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "qt-build-utils"
 version = "0.4.1"
-source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#455862f6a2c43d1ce98f699cbfd2af370aa70d10"
+source = "git+https://github.com/SfietKonstantin/cxx-qt?branch=sfos#37b4148c77029622478ca84e00e93e00e4944095"
 dependencies = [
  "thiserror",
  "versions",

--- a/lib/rust/Cargo.toml
+++ b/lib/rust/Cargo.toml
@@ -11,7 +11,6 @@ cxx = "1.0"
 cxx-qt-lib = { git = "https://github.com/SfietKonstantin/cxx-qt", branch = "sfos" }
 env_logger = "0.9"
 log = "0.4"
-open = "3.2"
 pretend = "0.4.0"
 pretend-reqwest = "0.4.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/lib/rust/build.rs
+++ b/lib/rust/build.rs
@@ -4,19 +4,19 @@ use std::{env, fs};
 fn main() {
     println!("cargo:rerun-if-changed=src/ffi.rs");
 
+    let source = Path::new(&env::var("OUT_DIR").unwrap()).join("cxxbridge");
+    cxx_qt_lib_headers::write_headers(source.join("include").join("cxx-qt-lib"));
+
     cxx_build::bridge("src/ffi.rs")
         .flag_if_supported("-std=c++17")
         .include(".")
         .compile("elephant-seal-rust");
 
     if let Ok(cmake_current_binary_dir) = env::var("CMAKE_CURRENT_BINARY_DIR") {
-        let source = Path::new(&env::var("OUT_DIR").unwrap()).join("cxxbridge");
         let target = Path::new(&cmake_current_binary_dir).join("cxxbridge");
         if target.exists() {
             fs::remove_dir_all(&target).unwrap();
         }
         copy_dir::copy_dir(source, &target).unwrap();
-
-        cxx_qt_lib_headers::write_headers(target.join("include").join("cxx-qt-lib"));
     }
 }

--- a/lib/rust/glue/glue.cpp
+++ b/lib/rust/glue/glue.cpp
@@ -3,8 +3,8 @@
 #include <cxx-qt-lib/qstring.h>
 #include <elephant-seal-rs/src/ffi.rs.h>
 
-void event_bus_send_display_code_input(EventBus &bus) {
-    EventBus::sendDisplayCodeInput(bus);
+void event_bus_send_open_code_url(EventBus &bus, const QString &url) {
+    EventBus::sendOpenCodeUrl(bus, url);
 }
 
 namespace {

--- a/lib/rust/glue/glue.h
+++ b/lib/rust/glue/glue.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QString>
+
 class EventBus;
 
-void event_bus_send_display_code_input(EventBus &bus);
+void event_bus_send_open_code_url(EventBus &bus, const QString &url);

--- a/lib/rust/src/mastodon.rs
+++ b/lib/rust/src/mastodon.rs
@@ -1,6 +1,5 @@
 mod login;
 
-use cxx_qt_lib::QString;
 use pretend::interceptor::NoopRequestInterceptor;
 use pretend::resolver::UrlResolver;
 use pretend::Pretend;
@@ -22,7 +21,6 @@ impl Mastodon {
     }
 
     pub fn init() {
-        // Force linking against cxx_qt_lib
-        QString::default();
+        env_logger::init();
     }
 }

--- a/lib/rust/src/mastodon/login.rs
+++ b/lib/rust/src/mastodon/login.rs
@@ -7,7 +7,7 @@ use pretend_reqwest::Client as RClient;
 const REDIRECT_URI: &str = "urn:ietf:wg:oauth:2.0:oob";
 
 impl Mastodon {
-    pub async fn prepare_login(&mut self, server: String) -> Result<()> {
+    pub async fn prepare_login(&mut self, server: String) -> Result<String> {
         let server_url = Url::parse(&server)?;
         let client = Pretend::for_client(RClient::default()).with_url(server_url);
 
@@ -22,7 +22,6 @@ impl Mastodon {
             "{}/oauth/authorize?response_type=code&client_id={}&redirect_uri={}",
             server, application.client_id, REDIRECT_URI
         );
-        open::that(login_url)?;
-        Ok(())
+        Ok(login_url)
     }
 }

--- a/lib/shim/shim.cpp
+++ b/lib/shim/shim.cpp
@@ -12,7 +12,7 @@ public:
 
     void prepareLogin(const QString &serverUrl, EventBus &bus) override {
         Q_UNUSED(serverUrl)
-        EventBus::sendDisplayCodeInput(bus);
+        EventBus::sendOpenCodeUrl(bus, serverUrl);
     }
 };
 

--- a/rpm/harbour-elephant-seal.spec
+++ b/rpm/harbour-elephant-seal.spec
@@ -78,7 +78,7 @@ export AR_aarch64_unknown_linux_gnu=aarch64-meego-linux-gnu-ar
 
 export CARGO_BUILD_TARGET=%SB2_TARGET
 
-%cmake -DRust_CARGO_TARGET=%SB2_TARGET .
+%cmake -DCMAKE_BUILD_TYPE=Release -DRust_CARGO_TARGET=%SB2_TARGET .
 make %{?_smp_mflags}
 # << build pre
 


### PR DESCRIPTION
This commit introduced Sailjail in the
.desktop file.

It also removed the use of Rust `open` to
open login URL, as it doesn't work with sandboxing. Instead, we use Qt's capabilities.